### PR TITLE
feat: busca de atividades por usuário (e-mail) na API e interface

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -110,6 +110,7 @@ def signup_for_activity(activity_name: str, email: str):
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
+
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
@@ -130,3 +131,19 @@ def unregister_from_activity(activity_name: str, email: str):
     # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+
+# Novo endpoint: Buscar atividades por e-mail
+@app.get("/activities/by-user/{email}")
+def get_activities_by_user(email: str):
+    """Retorna todas as atividades em que o usuário (e-mail) está inscrito."""
+    user_activities = []
+    for name, data in activities.items():
+        if email in data["participants"]:
+            user_activities.append({
+                "name": name,
+                "description": data["description"],
+                "schedule": data["schedule"],
+                "status": f"{len(data['participants'])}/{data['max_participants']} inscritos"
+            })
+    return {"email": email, "activities": user_activities}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,8 +1,47 @@
 document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
+  const userActivitiesList = document.getElementById("user-activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const searchUserForm = document.getElementById("search-user-form");
+  const searchUserEmail = document.getElementById("search-user-email");
+  // Função para buscar atividades por e-mail
+  async function fetchUserActivities(email) {
+    userActivitiesList.innerHTML = "<p>Buscando atividades...</p>";
+    userActivitiesList.classList.remove("hidden");
+    try {
+      const response = await fetch(`/activities/by-user/${encodeURIComponent(email)}`);
+      const data = await response.json();
+      if (data.activities && data.activities.length > 0) {
+        userActivitiesList.innerHTML = `<h4>Atividades de ${email}</h4>` +
+          data.activities.map(act => `
+            <div class="activity-card">
+              <h5>${act.name}</h5>
+              <p>${act.description}</p>
+              <p><strong>Horário:</strong> ${act.schedule}</p>
+              <p><strong>Status:</strong> ${act.status}</p>
+            </div>
+          `).join("");
+      } else {
+        userActivitiesList.innerHTML = `<p>Nenhuma atividade encontrada para <b>${email}</b>.</p>`;
+      }
+    } catch (error) {
+      userActivitiesList.innerHTML = `<p>Erro ao buscar atividades para <b>${email}</b>.</p>`;
+      console.error("Erro na busca de atividades por usuário:", error);
+    }
+  }
+
+  // Evento do formulário de busca
+  if (searchUserForm) {
+    searchUserForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const email = searchUserEmail.value.trim();
+      if (email) {
+        fetchUserActivities(email);
+      }
+    });
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -13,8 +13,15 @@
     </header>
 
     <main>
+
       <section id="activities-container">
         <h3>Available Activities</h3>
+        <form id="search-user-form" style="margin-bottom: 1em;">
+          <label for="search-user-email">Buscar atividades por e-mail:</label>
+          <input type="email" id="search-user-email" placeholder="exemplo@mergington.edu" required />
+          <button type="submit">Buscar</button>
+        </form>
+        <div id="user-activities-list" class="hidden"></div>
         <div id="activities-list">
           <!-- Activities will be loaded here -->
           <p>Loading activities...</p>


### PR DESCRIPTION
Implementa a busca de atividades por usuário (e-mail) tanto na API quanto na interface web:

- Novo endpoint GET `/activities/by-user/{email}` que retorna todas as atividades em que o usuário está inscrito.
- Campo de busca por e-mail na interface, exibindo as atividades do usuário buscado.

Resolve a issue #8.